### PR TITLE
charts resize when their parent element size changes

### DIFF
--- a/src/javascripts/kpi-gauge.js
+++ b/src/javascripts/kpi-gauge.js
@@ -75,13 +75,12 @@ var KPIGauge = function(parent, options) {
   //In the future, refactor kpi gauge sizing into sizeboxify
   window.addEventListener('resize:qd', resize, true);
 
-  //Special case: detect parent element size change that doesn't trigger resize event
-  //This can happen when the scrollbar appears 
+  //If the chart parent/container element size changes then resize the chart
   detectElementResize.addResizeListener(d3.select(parent).node(), checkForResize);
   function checkForResize() {
-    if(barWidth() > _chart.kpiBar.width() || barWidth() < _chart.kpiBar.width()) {
+    //Only resize if the chart has its dimension added meaning everything has loaded
+    if(dc.autoResize() === true && _chart.dimension() && _chart.group())
       resize();
-    }
   }
 
   return _chart;

--- a/src/javascripts/size-boxify.js
+++ b/src/javascripts/size-boxify.js
@@ -243,9 +243,6 @@ var sizeBoxify = function() {
     window.dispatchEvent(qdResize);
   };
 
-  //resize qd components on 'resize' if dc.autoResize() is true
-  window.addEventListener('resize', function() {if(dc.autoResize() === true) dc.triggerQDResize();})
-
   return dc;
 };
 
@@ -273,19 +270,17 @@ var sizeBoxifyMixin = function(chart) {
   //add a custom listener to window that all qd components will use
   window.addEventListener('resize:qd', chart.resize, true);
 
-  //Special case: detect parent element size change that doesn't trigger resize event
-  //This can happen when the scrollbar appears 
-  detectElementResize.addResizeListener(container, checkForResize);
-  function checkForResize() {
-    if(chart.getDynamicWidth() > chart.width() || chart.getDynamicWidth < chart.width()) {
+
+  //If the chart parent/container element size changes then resize the chart
+  detectElementResize.addResizeListener(container, resizeFunc);
+  function resizeFunc() {
+    //Only resize if the chart has its dimension added meaning everything has loaded
+    if(dc.autoResize() === true && chart.dimension())
       chart.resize();
-    }
   }
+
 
   return chart;
 }
 
 module.exports = sizeBoxify;
-
-
-


### PR DESCRIPTION
This fix covers a lot of issues like scrollbar resizing things, and browser maximize not triggering resize event. The browser resize event is no longer used with resizing, and this is just as performant. 
