### PR TITLE
remove strike through and tool tips for small screen size

### DIFF
--- a/src/stylesheets/common.scss
+++ b/src/stylesheets/common.scss
@@ -1,3 +1,29 @@
+
+//Styles for mobile screen size
+@media only screen and (max-width: 36em) {
+	
+	//filter builder strike through not needed on hover
+	body .filter-builder li.filtered-field ul.filter-value-list > li.filter-value {
+		&:hover {
+			text-decoration: none ;
+			color: #666;
+			border: 1px solid #d3d3d3;
+		}
+		
+		//tap/active give strike through 
+		&:active {
+			text-decoration: line-through;
+			border-color:#eaeaea;
+			color:#aaa;
+		}
+	}
+
+	//Do not show tool tips 
+	.d3-tip-mouse {
+		display: none;
+	}
+}
+
 .hide-visually {
 	display: none;
 }


### PR DESCRIPTION
Fix the strikethroughs and the tooltips for mobile size. This covers small screen size, but does not cover some large touch screens like ipads which would probably be more work than it's worth.
